### PR TITLE
add talk descriptions

### DIFF
--- a/Talks/Readme.md
+++ b/Talks/Readme.md
@@ -46,3 +46,136 @@
 * "Hitting the gym: controlling traffic with Reinforcement Learning" - Steven Nooijen
 * "Step by step face swap" - Sylwester Brzęczkowski
 * [Optimizing Deep Neural Network Layer Topology with Delve](https://docs.google.com/presentation/d/143p3B9V-JJKtHpKse91KboN0Z03NRK3Ze2l0bSLcom8/view) - Justin Shenk
+
+
+## Lecture descriptions
+
+#### [PyTorch 1.0: now and in the future](https://pydata.org/warsaw2018/schedule/presentation/11/) - Adam Paszke
+PyTorch is one of the main tools used for machine learning research these days. It’s been developed in beta mode for over 2 years, but this October, a release candidate for 1.0 version has been finally released! In this talk, I’ll briefly introduce the library, and then move on to showcase the cutting edge features we introduced recently.
+
+#### [Deep Learning for 3D World: Point Clouds](https://pydata.org/warsaw2018/schedule/presentation/32/) - Marcin Mosiołek
+The talk is about to provide a gentle introduction into the world of 3D deep learning techniques, considering basic aspects such as input representation, typical problems and most popular models. After the talk you should be able understand common challenges occurring when working with point clouds, and more importantly, you should be able to tackle them properly.
+
+#### [Where visual meets textual. Luna - overview.](https://pydata.org/warsaw2018/schedule/presentation/51/) - Sylwia Brodacka
+Luna is a general-purpose programming language with an intuitive visual interface that is dedicated to data science applications. In this presentation we will show how to improve interpretation of results and communication, including with non-technical business experts, by making data visualization the driving component of data science workflow.
+
+#### [Can you trust neural networks?](https://pydata.org/warsaw2018/schedule/presentation/3/) - Mateusz Opala
+Recently neural networks have become superior in many machine learning tasks. However, they are more difficult to interpret than simpler models such as decision trees. Such a condition is not acceptable in industries like healthcare or law. In this talk, I will talk on unified approach to explain the output of any machine learning model, especially neural networks.
+
+#### [From Data to Deliverable](https://pydata.org/warsaw2018/schedule/presentation/52/) - Steph Samson
+The data we need is sourced from different places. The data could even come in different formats. I will talk about how I used data from different APIs, cleaned and preprocessed it, and wrapped it up under a new API for a restaurant discovery service. This talk is for attendees looking to jump into the data science industry for the first time.
+
+#### [Overview of imbalanced data prediction methods](https://pydata.org/warsaw2018/schedule/presentation/37/) - Robert Kostrzewski
+Imbalance ratio is a definition describing relation of frequency of data classified to following classification classes. Assuming binary classification as datasets' domain, higher the ratio is, more disproportion on feature existence distribution is observed. The talk’s goal is to compare, in both theoretical and practical ways, various fresh methods of dealing with the problem.
+
+#### [Recognizing products from raw text descriptions using “shallow” and “deep” machine learning](https://pydata.org/warsaw2018/schedule/presentation/17/) - Tymoteusz Wołodźko
+We will compare “shallow” and “deep” machine learning approaches to solving a natural language processing problem. Pros, cons and consequences of both choices will be discussed.
+
+#### [How I learnt computer vision by playing pool](https://pydata.org/warsaw2018/schedule/presentation/33/) - Łukasz Kopeć
+Is there a way to automatically say how warped a pool table is, just by looking at a video of people playing? In this talk I will explain how I did that using OpenCV for pool balls tracking, and how more heuristic approaches may improve this model’s performance. I will also present a simple analysis of the effect of different levels of warp on players’ scores.
+
+#### [Distributed deep learning and why you may not need it](https://pydata.org/warsaw2018/schedule/presentation/38/) - Jakub Sanojca
+Deep learning thrives with always bigger networks and always growing datasets but single machine can only handle so much. When to scale to multiple machines and how do do it efficiently? What pros and cons available options have and what is theory behind their approach to distributed training? In this talk we will answer those questions and show what problems we are trying to solve at Avast.
+
+#### [AI meets Art](https://pydata.org/warsaw2018/schedule/presentation/9/) - Agata Chęcińska
+Intersection of artificial intelligence and art world is an intriguing concept. I will show several examples of this intersection, with the focus on the AI based "Museum Treasures" game, a winning solution from the HackArt: a hackathon organised by the National Museum in Warsaw. I will also touch on the topic of analogies between creative processes and machine learning processes.
+
+#### [Hand in hand with weak supervision using snorkel](https://pydata.org/warsaw2018/schedule/presentation/34/) - Szymon Wojciechowski
+In Natural Language Processing, where we want to use a supervised model the frequent problem is the availability of labels. One way of circumventing tedious and cost-intensive manual annotation of (tens) of thousands of samples may be weak supervision, where heuristics, fragmentary datasets with annotations and crowd-sourced indications (on a fraction of samples) can be unified to generate labels.
+
+#### [3d visualisation in a Jupyter notebook](https://pydata.org/warsaw2018/schedule/presentation/36/) - Marcin Kostur
+K3D-jupyter is a notebook visualization package which we have been developing since 2015. It offers a powerful and efficient tool with a simple interface to appealing techniques like volumetric rendering, meshes, lines, and points. Its performance allows for smooth visualization of datasets like 100 million points and updates with their position from python interface.
+
+#### [Deep Learning Semantic Segmentation for Nucleus Detection](https://pydata.org/warsaw2018/schedule/presentation/16/) - Dawid Rymarczyk
+Semantic segmentation is the process which aims to classify individual pixels of an image. Recently, Kaggle hosted the 2018 Data Science Bowl competition dedicated to nucleus detection and segmentation based on microscopic images. In this talk, I will present two approaches to this problem, based on U-Net and Mask R-CNN.
+
+#### [Bit to Qubit: Data in the age of quantum computers.](https://pydata.org/warsaw2018/schedule/presentation/22/) - Shahnawaz Ahmed
+We will discuss the qubit, a quantum bit, and what data processing and machine learning in the quantum computing era might look like using python based open- source tools.
+
+#### [Transfer Learning for Neural Networks](https://pydata.org/warsaw2018/schedule/presentation/40/) - Dominik Lewy
+During the session I will explain the notion of transfer learning both in context of single task learning and recently very popular multitask models. I will give a brief overview of the state of the art approaches to machine translation (zero shot translation) and image recognition with a focus on transfer learning.
+
+#### [Spot the difference: train your image analytics model to recognize fine grained similarity](https://pydata.org/warsaw2018/schedule/presentation/20/) - Katarina Milosevic, Ioana Gherman
+Imagine two images of the same car model, same color and with small scratches on bumpers. How would you make a machine look at the scratches and decide if they are the same? This is a story about the implementation of a new structure of neural network trained on “triplets” of images which recognizes fine grained images similarity based on Deep Ranking algorithm.
+
+#### [In Browser AI - neural networks for everyone](https://pydata.org/warsaw2018/schedule/presentation/26/) - Kamila Stepniowska
+Let's talk about In Browser AI - the open source educational project brings together Python & JavaScript.  Bring deep learning demos of your research papers, commercial or side projects to the browsers. Create interactive explanations and tutorials, using interactive environment! Train in Python, show in JavaScript.
+
+#### [Using convolutional neural networks to analyze bacteriophages DNA](https://pydata.org/warsaw2018/schedule/presentation/55/) - Michał Jadczuk
+With the overuse of antibiotics causing the emergence of superbugs, people all over the world are looking into their safer alternatives. Bacteriophages - or viruses that feed on the bacteria - might just be one of them. All phage strains must be carefully analyzed before commercial use, though. This presentation will explain how machine learning can speed up the evaluation of bacteriophages DNA.
+
+#### [Comixify: Turning videos into comics](https://pydata.org/warsaw2018/schedule/presentation/7/) - Adam Svystun
+In our talk, we will present a Web-based working solution for video comixification - a task of converting a video into a comics. We will disclose technical details of how our comixification engine works and, finally, we will give a first public presentation of a working video comixification demo available at comixify.ii.pw.edu.pl.
+
+#### [High Performance Data Processing in Python](https://pydata.org/warsaw2018/schedule/presentation/15/) - Donald Whyte
+numpy and numba are popular Python libraries for processing large quantities of data. This talk explains how numpy/numba work under the hood and how they use vectorisation to process large amounts of data extremely quickly. We use these tools to reduce the processing time of a large, real 600GB dataset from one month to 40 minutes, even when the code is run on a single Macbook Pro.
+
+#### [What ad is this?](https://pydata.org/warsaw2018/schedule/presentation/31/) - Adam Witkowski
+Ads on the web often consist of a picture with some text. Based on this information, can you tell what exactly is advertised? In this talk I will describe a system that automatically categorizes ads seen on the web. I will talk about potential approaches to this problem and describe in detail the chosen solution. This system was created as a joint project between Gemius and MIM Solutions.
+
+#### [Spammers vs. Data: My everyday fight](https://pydata.org/warsaw2018/schedule/presentation/4/) - Juan De Dios Santos
+LOVOO, a dating app, is attractive to spam. These spammers disguise themselves as real users, using believable images and accurate descriptions on their profiles to lure our community into chatting with them. This presentation is on everything Antispam. In it, I will talk about the architecture of the system, data, and the algorithms and methods we employ to fight the spammers.
+
+#### [Analysing Russian Troll Tweets data with Python](https://pydata.org/warsaw2018/schedule/presentation/27/) - Mia Polovina
+This talk focuses on the insights gathered from analysis of Russian Troll Tweets, a dataset created by researchers at Clemson University and released on Github by FiveThirtyEight.
+
+#### [Pragmatic application of Machine Learning in commercial products.](https://pydata.org/warsaw2018/schedule/presentation/53/) - Łukasz Słabiński
+I will show a few interesting examples of application the state of the art Machine Learning techniques in products used by millions of users. In this context, I will discuss also general but pragmatic need of R&D in the area of Artificial Intelligence from the perspective of Samsung Electronics - the world's largest information technology company, consumer electronics and chips maker.
+
+#### [Cognimates: Read, Write and Tinker with AI](https://pydata.org/warsaw2018/schedule/presentation/64/) - Stefania Druga
+Much of our daily life is quietly being reshaped by AI, with 47 million people already using Alexa in their homes in USA only and an entire generation of children growing up with this technology. I believe the best way to understand how AI works is by doing.
+
+#### [The Neural Aesthetic](https://pydata.org/warsaw2018/schedule/presentation/65/) - Gene Kogan
+Over the past several years, two trends in machine learning have converged to pique the curiosity of artists working with code: the proliferation of powerful open source deep learning frameworks like TensorFlow and Torch, and the emergence of data-intensive generative models for hallucinating images, sounds, and text as though they came from the oeuvre of Shakespeare, Picasso, or just a gigantic database of digitized cats.
+
+#### [Towards Data Pipeline Hyperparameter Optimization](https://pydata.org/warsaw2018/schedule/presentation/66/) - Alex Quemy
+It is commonly accepted that about 80% of data scientists time is spent on preparing data, including setting up the proper data pipeline or ETL. For a large part, the proper configuration of a given data pipeline is the result of the data scientist experience and Subject Matter Expert knowledge, plus a dose of arbitrary decisions. What if most of this work could be automated? Better, is it possible to find some universal pipeline configurations that can work well on a wide range of domains and thus transfer what has been learn on one dataset to another?
+
+#### [Similarity learning using deep neural networks](https://pydata.org/warsaw2018/schedule/presentation/14/) - Jacek Komorowski
+Deep neural network give very good results in visual object recognition tasks, but they require large number of training examples from each category. I'll present a class of neural network architectures, that can be used when only few training examples from each class are available. They are based on 'similarity learning' concept and can be used to solve various practical problems.
+
+#### [Application of Recurrent Neural Networks to innovative drug design](https://pydata.org/warsaw2018/schedule/presentation/30/) - Rafał A. Bachorz
+The presentation shows the application of Recurrent Neural Network to the problem of innovative drug design. The audience will also have an opportunity to get familiar with modern cheminformtics libraries available in Python ecosystem. The final element of the preeentation is live demonstration of the pretrained, generative predictove model applied to generation of new molecules.
+
+#### [Computer vision challenges in drug discovery](https://pydata.org/warsaw2018/schedule/presentation/10/) - Dr Maciej Hermanowicz
+I will present a high-level overview of how automated image analysis approaches can be incorporated into pharmaceutical discovery pipelines. By taking a look at two GSK case studies I will demonstrate how to apply computer vision techniques to featurize imaging data, enabling the use of standard machine learning algorithms. I will highlight how these techniques benefit the drug discovery process.
+
+#### [Learning to rank @ allegro.pl](https://pydata.org/warsaw2018/schedule/presentation/35/) - Tomasz Bartczak
+We will share our experience gained during development of ‘learning to rank’ system in an e-commerce setting. Our talk will cover both theoretical and practical aspect of the project - general approach in learning to rank, suitable tools, data and modelling pipeline and production deployment considerations. Finally, we will share some tips and tricks that come from actual, practical insights.
+
+#### [The smart shopping basket: A Case Study with deep learning, Intel Movidius and AWS](https://pydata.org/warsaw2018/schedule/presentation/25/) - Marcin Stachowiak
+Our objective was to build a connected intelligent shopping cart/basket, which will detect, which products have been placed in it and will generate shopping recommendations for the current cart user. We have used the state-of-the-art, real-time object detection system - YOLOv2, which deep architecture has been reduced to accelerate the evaluation on the Raspberry PI device and the Intel® Movidius.
+
+#### [It is never too much: training deep learning models with more than one modality.](https://pydata.org/warsaw2018/schedule/presentation/21/) - Adam Słucki
+Using visual features alone is not enough to fully exploit content of social media videos. We propose a whole pipeline for extracting textual data embedded in videos and fusing them with the original visual data to predict drops in viewer’s retention.
+
+#### [Visualize, Explore and Explain Predictive ML Models](https://pydata.org/warsaw2018/schedule/presentation/19/) - Przemyslaw Biecek
+Why you need tools for exploration, visualisation and explanation for predictive models? During the talk I will present use cases in which model interpretability is crucial and overview tools that support model interpretability (Ceteris Paribus, Break Down, LIME, live, auditor). See more at DALEXverse: https://github.com/pbiecek/DALEX
+
+#### [The Dawn of Mind Reading in Python](https://pydata.org/warsaw2018/schedule/presentation/18/) - Krzysztof Kotowski
+An introduction to EEG signal analysis from low-cost devices using the MNE Python package. A review of advances and the future of "mind reading".
+
+#### [Uncertainty estimation and Bayesian Neural Networks](https://pydata.org/warsaw2018/schedule/presentation/57/) - Marcin Możejko
+We will show how to assess the uncertainty of deep neural networks. We will cover Bayesian Deep Learning and other out-of-distribution detection methods. The talk will include examples that will show how to implement the methods in Pytorch.
+
+#### [A deep revolution in speech processing and analysis](https://pydata.org/warsaw2018/schedule/presentation/54/) - Pawel Cyrta
+In the past two years, we’ve seen the industry discovery of speech as a critical interface protocol between humans and machines, especially for cloud- based information queries driving by speech recognition. These create significant new opportunities for every application that touches audio or video - opening up new potential for improved intelligibility, personalisation and customer “stickiness”.
+
+#### [Predicting preterm birth with convolutional neural nets](https://pydata.org/warsaw2018/schedule/presentation/13/) - Tomasz Włodarczyk
+The desirable date of the birth of a child follows the full duration of pregnancy. According to WHO data, 15 million children are born prematurely every year, of which 1.1 million dies, unfortunately. In this talk, we will present how to improve prediction rate of the spontaneous preterm delivery using deep learning and computer vision methods.
+
+#### [Can you enhance that? Single Image Super Resolution](https://pydata.org/warsaw2018/schedule/presentation/28/) - Katarzyna Kańska
+The talk will introduce a problem of upscaling a picture with as small loss of quality as possible using deep learning techniques. What metric to use when evaluating the solution? Upsample the image in the beginning or near the end of your neural network? Which upscaling layers to use? Answers to these and more questions on this topic will be discussed.
+
+#### [Burger Quest: finding the best hamburger in town!](https://pydata.org/warsaw2018/schedule/presentation/49/) - Roel Bertens
+At our company we like to eat burgers. Also, we like to analyse data. So on one Friday we decided to leverage our expertise and use online reviews, ratings and images to find us the best hamburger nearby our office in Amsterdam. This talk will be about that quest, and about the (overkill of) tools that we used for this purpose: Scrapy, ElasticSearch, Google's Vision API and BigQuery.
+
+#### [Hitting the gym: controlling traffic with Reinforcement Learning](https://pydata.org/warsaw2018/schedule/presentation/8/) - Steven Nooijen
+Finally a good real-life use case for Reinforcement Learning (RL): traffic control! In this talk I will show you how we hooked up traffic simulation software to Python and how we built our own custom `gym` environment to run RL experiments with `keras-rl` for a simple 4-way intersection.
+
+#### [Step by step face swap.](https://pydata.org/warsaw2018/schedule/presentation/24/) - Sylwester Brzęczkowski
+I will present how to implement a face swap. We will go step by step from simple “copy & paste” face on another image to fully functioning and nice looking face swap.
+
+#### [Optimizing Deep Neural Network Layer Topology with Delve](https://pydata.org/warsaw2018/schedule/presentation/23/) - Justin Shenk
+Identifying the number of hidden units in a fully connected layer is considered a heuristically-guided craft. A PyTorch library, Delve, was developed that allows identifying the degree of over-parameterization of a layer, thus guiding architecture selection. The library compares the intrinsic dimensionality of the layer over training, providing the user with live feedback during training.
+


### PR DESCRIPTION
add lecture descriptions parsed from PyData website

notebook with code is available at https://github.com/pafnucy/PyData-Warsaw-Conference-2018/blob/description-listing/parse_pydata_website.ipynb